### PR TITLE
adding community specification license materials 

### DIFF
--- a/governance/0._CS_Contributor_License_Agreement.md
+++ b/governance/0._CS_Contributor_License_Agreement.md
@@ -1,0 +1,18 @@
+# Community Specification Contributor License Agreement 1.0
+
+By making a Contribution to this repository, I agree to the terms of the following documents located at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0):
+
+(a) Community Specification License 1.0 (.0_Community_Specification_License-v1.md)
+
+(b) Community Specification Governance Policy 1.0 (5._Governance.md)
+
+(c) Community Specification Contribution Policy 1.0 (6._Contributing.md)
+
+(d) Community Specification Code of Conduct (8._Code_of_Conduct.md)
+
+
+In addition, for source code contributions, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or (b) The contribution is based upon previous work that, to the best  of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it. (d) I understand and agree that this working group and the contribution may be public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this agreement or the open source license(s) involved.
+
+I represent that I am legally entitled to make the grants set forth in the documents above.  If my employer(s) has rights to intellectual property that may be infringed by the materials developed by this Working Group, I represent that I have received permission to enter these agreements on behalf of that employer.

--- a/governance/1._Community_Specification_License-v1.md
+++ b/governance/1._Community_Specification_License-v1.md
@@ -1,0 +1,99 @@
+# Community Specification License 1.0
+
+**The Purpose of this License.**  This License sets forth the terms under which 1) Contributor will participate in and contribute to the development of specifications, standards, best practices, guidelines, and other similar materials under this Working Group, and 2) how the materials developed under this License may be used.  It is not intended for source code.  Capitalized terms are defined in the License’s last section.
+
+**1.	Copyright.**
+
+**1.1.	Copyright License.**  Contributor grants everyone a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) copyright license, without any obligation for accounting, to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute any materials it submits to the full extent of its copyright interest in those materials. Contributor also acknowledges that the Working Group may exercise copyright rights in the Specification, including the rights to submit the Specification to another standards organization.
+
+**1.2.	Copyright Attribution.**  As a condition, anyone exercising this copyright license must include attribution to the Working Group in any derivative work based on materials developed by the Working Group.  That attribution must include, at minimum, the material’s name, version number, and source from where the materials were retrieved.  Attribution is not required for implementations of the Specification.
+
+**2.	Patents.**
+
+**2.1.	Patent License.**
+
+**2.1.1.	As a Result of Contributions.**
+
+**2.1.1.1.	As a Result of Contributions to Draft Specifications.**  Contributor grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims in 1) Contributor’s Contributions and 2) to the Draft Specification that is within Scope as of the date of that Contribution, in both cases for Licensee’s Implementation of the Draft Specification, except for those patent claims excluded by Contributor under Section 3.  
+
+**2.1.1.2.	For Approved Specifications.**  Contributor grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims included the Approved Specification that are within Scope for Licensee’s Implementation of the Approved Specification, except for those patent claims excluded by Contributor under Section 3.
+
+**2.1.2.	Patent Grant from Licensee.**  Licensee grants each other Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims for its Implementation, except for those patent claims excluded under Section 3.
+
+**2.1.3.	Licensee Acceptance.**  The patent grants set forth in Section 2.1 extend only to Licensees that have indicated their agreement to this License as follows: 
+
+**2.1.3.1.	Source Code Distributions.**  For distribution in source code, by including this License in the root directory of the source code with the Implementation;
+
+**2.1.3.2.	Non-Source Code Distributions.**  For distribution in any form other than source code, by including this License in the documentation, legal notices, via notice in the software, and/or other written materials provided with the Implementation; or
+
+**2.1.3.3.	Via Notices.md.**  By issuing pull request or commit to the Specification’s repository’s Notices.md file by the Implementer’s authorized representative, including the Implementer’s name, authorized individual and system identifier, and Specification version.
+
+**2.1.4.	Defensive Termination.**  If any Licensee files or maintains a claim in a court asserting that a Necessary Claim is infringed by an Implementation, any licenses granted under this License to the Licensee are immediately terminated unless 1) that claim is directly in response to a claim against Licensee regarding an Implementation, or 2) that claim was brought to enforce the terms of this License, including intervention in a third-party action by a Licensee.
+
+**2.1.5.	Additional Conditions.**  This License is not an assurance (i) that any of Contributor’s copyrights or issued patent claims cover an Implementation of the Specification or are enforceable or (ii) that an Implementation of the Specification would not infringe intellectual property rights of any third party.
+
+**2.2.	Patent Licensing Commitment.**  In addition to the rights granted in Section 2.1, Contributor agrees to grant everyone a no charge, royalty-free license on reasonable and non-discriminatory terms to Contributor’s Necessary Claims that are within Scope for:
+1) Implementations of a Draft Specification, where such license applies only to those Necessary Claims infringed by implementing Contributor's Contribution(s) included in that Draft Specification, and
+2) Implementations of the Approved Specification. 
+
+This patent licensing commitment does not apply to those claims subject to Contributor’s Exclusion Notice under Section 3.
+
+**2.3.	Effect of Withdrawal.**  Contributor may withdraw from the Working Group by issuing a pull request or commit providing notice of withdrawal to the Working Group repository’s Notices.md file.  All of Contributor’s existing commitments and obligations with respect to the Working Group up to the date of that withdrawal notice will remain in effect, but no new obligations will be incurred. 
+
+**2.4.	Binding Encumbrance.**  This License is binding on any future owner, assignee, or party who has been given the right to enforce any Necessary Claims against third parties.
+
+**3.	Patent Exclusion.**
+
+**3.1.	As a Result of Contributions.**  Contributor may exclude Necessary Claims from its licensing commitments incurred under Section 2.1.1 by issuing an Exclusion Notice within 45 days of the date of that Contribution.  Contributor may not issue an Exclusion Notice for any material that has been included in a Draft Deliverable for more than 45 days prior to the date of that Contribution.
+
+**3.2.	As a Result of a Draft Specification Becoming an Approved Specification.**  Prior to the adoption of a Draft Specification as an Approved Specification, Contributor may exclude Necessary Claims from its licensing commitments under this Agreement by issuing an Exclusion Notice.  Contributor may not issue an Exclusion Notice for patents that were eligible to have been excluded pursuant to Section 3.1.
+
+**4.	Source Code License.**  Any source code developed by the Working Group is solely subject the source code license included in the Working Group’s repository for that code.  If no source code license is included, the source code will be subject to the MIT License.
+
+**5.	No Other Rights.**  Except as specifically set forth in this License, no other express or implied patent, trademark, copyright, or other rights are granted under this License, including by implication, waiver, or estoppel.
+
+**6.	Antitrust Compliance.**  Contributor acknowledge that it may compete with other participants in various lines of business and that it is therefore imperative that they and their respective representatives act in a manner that does not violate any applicable antitrust laws and regulations.  This License does not restrict any Contributor from engaging in similar specification development projects. Each Contributor may design, develop, manufacture, acquire or market competitive deliverables, products, and services, and conduct its business, in whatever way it chooses.  No Contributor is obligated to announce or market any products or services.  Without limiting the generality of the foregoing, the Contributors agree not to have any discussion relating to any product pricing, methods or channels of product distribution, division of markets, allocation of customers or any other topic that should not be discussed among competitors under the auspices of the Working Group.
+
+**7.	Non-Circumvention.**  Contributor agrees that it will not intentionally take or willfully assist any third party to take any action for the purpose of circumventing any obligations under this License.
+
+**8.	Representations, Warranties and Disclaimers.**
+
+**8.1.  Representations, Warranties and Disclaimers.**  Contributor and Licensee represents and warrants that 1) it is legally entitled to grant the rights set forth in this License and 2) it will not intentionally include any third party materials in any Contribution unless those materials are available under terms that do not conflict with this License.  IN ALL OTHER RESPECTS ITS CONTRIBUTIONS ARE PROVIDED "AS IS." The entire risk as to implementing or otherwise using the Contribution or the Specification is assumed by the implementer and user. Except as stated herein, CONTRIBUTOR AND LICENSEE EXPRESSLY DISCLAIM ANY WARRANTIES (EXPRESS, IMPLIED, OR OTHERWISE), INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT, FITNESS FOR A PARTICULAR PURPOSE, CONDITIONS OF QUALITY, OR TITLE, RELATED TO THE CONTRIBUTION OR THE SPECIFICATION.  IN NO EVENT WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. Any obligations regarding the transfer, successors in interest, or assignment of Necessary Claims will be satisfied if Contributor or Licensee notifies the transferee or assignee of any patent that it knows contains Necessary Claims or necessary claims under this License. Nothing in this License requires Contributor to undertake a patent search. If Contributor is 1) employed by or acting on behalf of an employer, 2) is making a Contribution under the direction or control of a third party, or 3) is making the Contribution as a consultant, contractor, or under another similar relationship with a third party, Contributor represents that they have been authorized by that party to enter into this License on its behalf.
+
+**8.2.  Distribution Disclaimer.**  Any distributions of technical information to third parties must include a notice materially similar to the following: “THESE MATERIALS ARE PROVIDED “AS IS.” The Contributors and Licensees expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to the materials.  The entire risk as to implementing or otherwise using the materials is assumed by the implementer and user. IN NO EVENT WILL THE CONTRIBUTORS OR LICENSEES BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.”
+
+**9.	Definitions.**
+
+**9.1.	Affiliate.** “Affiliate” means an entity that directly or indirectly Controls, is Controlled by, or is under common Control of that party.
+
+**9.2.	Approved Specification.**  “Approved Specification” means the final version and contents of any Draft Specification designated as an Approved Specification as set forth in the accompanying Governance.md file.
+
+**9.3.	Contribution.**  “Contribution” means any original work of authorship, including any modifications or additions to an existing work, that Contributor submits for inclusion in a Draft Specification, which is included in a Draft Specification or Approved Specification.
+
+**9.4.	Contributor.** “Contributor” means any person or entity that has indicated its acceptance of the License 1) by making a Contribution to the Specification, or 2) by entering into the Community Specification Contributor License Agreement for the Specification.  Contributor includes its Affiliates, assigns, agents, and successors in interest.
+
+**9.5.	Control.**  “Control” means direct or indirect control of more than 50% of the voting power to elect directors of that corporation, or for any other entity, the power to direct management of such entity.
+
+**9.6.	Draft Specification.**  “Draft Specification” means all versions of the material (except an Approved Specification) developed by this Working Group for the purpose of creating, commenting on, revising, updating, modifying, or adding to any document that is to be considered for inclusion in the Approved Specification. 
+
+**9.7.	Exclusion Notice.**  “Exclusion Notice” means a written notice made by making a pull request or commit to the repository’s Notices.md file that identifies patents that Contributor is excluding from its patent licensing commitments under this License.  The Exclusion Notice for issued patents and published applications must include the Draft Specification’s name, patent number(s) or title and application number(s), as the case may be, for each of the issued patent(s) or pending patent application(s) that the Contributor is excluding from the royalty-free licensing commitment set forth in this License.  If an issued patent or pending patent application that may contain Necessary Claims is not set forth in the Exclusion Notice, those Necessary Claims shall continue to be subject to the licensing commitments under this License.  The Exclusion Notice for unpublished patent applications must provide either: (i) the text of the filed application; or (ii) identification of the specific part(s) of the Draft Specification whose implementation makes the excluded claim a Necessary Claim.  If (ii) is chosen, the effect of the exclusion will be limited to the identified part(s) of the Draft Specification.
+
+**9.8.	Implementation.**  “Implementation” means making, using, selling, offering for sale, importing or distributing any implementation of the Specification 1) only to the extent it implements the Specification and 2) so long as all required portions of the Specification are implemented.
+
+**9.9.	License.**  “License” means this Community Specification License.
+
+**9.10.	Licensee.**  “Licensee” means any person or entity that has indicated its acceptance of the License as set forth in Section 2.1.3.  Licensee includes its Affiliates, assigns, agents, and successors in interest.
+
+**9.11.	Necessary Claims.**  “Necessary Claims” are those patent claims, if any, that a party owns or controls, including those claims later acquired, that are necessary to implement the required portions (including the required elements of optional portions) of the Specification that are described in detail and not merely referenced in the Specification.
+
+**9.12.	Specification.**  “Specification” means a Draft Specification or Approved Specification included in the Working Group’s repository subject to this License, and the version of the Specification implemented by the Licensee.
+
+**9.13.	Scope.**  “Scope” has the meaning as set forth in the accompanying Scope.md file included in this Specification’s repository. Changes to Scope do not apply retroactively.  If no Scope is provided, each Contributor’s Necessary Claims are limited to that Contributor’s Contributions.
+
+**9.14.	Working Group.**  “Working Group” means this project to develop specifications, standards, best practices, guidelines, and other similar materials under this License.
+
+
+
+*The text of this Community Specification License is Copyright 2020 Joint Development Foundation and is licensed under the Creative Commons Attribution 4.0 International License available at https://creativecommons.org/licenses/by/4.0/.*
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/governance/2._Scope.md
+++ b/governance/2._Scope.md
@@ -1,0 +1,5 @@
+# Scope
+
+[Include a detailed description of this Working Group’s Scope.  This Scope is important is it establishes the bounds of each contributor's and licensee's patent commitment. For guidance on drafting an appropriate Scope, you may find [ISO's guidance (see page 5)](https://www.iso.org/files/live/sites/isoorg/files/developing_standards/docs/en/how-to-write-standards.pdf "ISO How To Write Standards Guide") helpful.]
+
+Any changes of Scope are not retroactive. 

--- a/governance/3._Notices.md
+++ b/governance/3._Notices.md
@@ -1,0 +1,58 @@
+# Notices
+
+## Code of Conduct
+
+Contact for Code of Conduct issues or inquires:  _________________
+
+[Ideally list two different individuals above (not a generic mailing list) as someone submitting a Code of Conduct complaint will want to know exactly who is receiving the complaint. We recommend two individuals in the case one of the individuals is the subject of or directly involved in the subject of a complaint.]
+
+
+## License Acceptance
+
+Per Community Specification License 1.0 Section 2.1.3.3, Licensees may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification’s repository’s Notice.md file, including the Licensee’s name, authorized individuals' names, and repository system identifier (e.g. GitHub ID), and specification version.
+
+A Licensee may consent to accepting the current Community Specification License version or any future version of the Community Specification License by indicating "or later" after their specification version.
+
+---------------------------------------------------------------------------------
+
+Licensee’s name:
+
+Authorized individual and system identifier:
+
+Specification version:
+
+---------------------------------------------------------------------------------
+
+## Withdrawals
+
+Name of party withdrawing:
+
+Date of withdrawal:  
+
+---------------------------------------------------------------------------------
+
+## Exclusions
+
+This section includes any Exclusion Notices made against a Draft Deliverable or Approved Deliverable as set forth in the Community Specification Development License.  Each Exclusion Notice must include the following information:
+
+-	Name of party making the Exclusion Notice:
+
+-	Name of patent owner:
+
+-	Specification:
+
+-	Version number:
+
+**For issued patents and published patent applications:**
+
+	(i)	patent number(s) or title and application number(s), as the case may be:
+
+	(ii)	identification of the specific part(s) of the Specification whose implementation makes the excluded claim a Necessary Claim.
+
+**For unpublished patent applications must provide either:**
+
+	(i) the text of the filed application; or
+    
+	(ii) identification of the specific part(s) of the Specification whose implementation makes the excluded claim a Necessary Claim.
+
+-----------------------------------------------------------------------------------------

--- a/governance/4._License.md
+++ b/governance/4._License.md
@@ -1,0 +1,13 @@
+# Licenses
+
+## Specification License
+
+Specifications in the repository are subject to the **Community Specification License 1.0** available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
+
+## Source Code License
+
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license unless otherwise designated. In the case of any conflict or confusion within this specification repository between the Community Specification License and the MIT or other designated license, the terms of the Community Specification License shall apply.
+
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license unless otherwise marked.
+
+In the case of any conflict or confusion within this specification repository between the Community Specification License and the designated source code license, the terms of the Community Specification License shall apply.

--- a/governance/5._Governance.md
+++ b/governance/5._Governance.md
@@ -1,0 +1,51 @@
+# Community Specification Governance Policy 1.0
+
+This document provides the governance policy for specifications and other documents developed using the Community Specification process in a repository (each a “Working Group”).  Each Working Group and must adhere to the requirements in this document.
+
+## 1.	Roles.
+
+Each Working Group may include the following roles. Additional roles may be adopted and documented by the Working Group.
+
+**1.1.	Maintainer.** “Maintainers” are responsible for organizing activities around developing, maintaining, and updating the specification(s) developed by the Working Group.  Maintainers are also responsible for determining consensus and coordinating appeals.  Each Working Group will designate one or more Maintainer for that Working Group.  A Working Group may select a new or additional Maintainer(s) upon Approval of the Working Group Participants.  
+
+**1.2.	Editor.**  “Editors” are responsible for ensuring that the contents of the document accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines. Each Working Group will designate an Editor for that Working Group.  A Working Group may select a new Editor upon Approval of the Working Group Participants.
+
+**1.3.	Participants.**  “Participants” are those that have made Contributions to the Working Group subject to the Community Specification License.
+
+## 2.	Decision Making.
+
+**2.1.	Consensus-Based Decision Making.**  Working Groups make decisions through a consensus process (“Approval” or “Approved”).  While the agreement of all Participants is preferred, it is not required for consensus.  Rather, the Maintainer will determine consensus based on their good faith consideration of a number of factors, including the dominant view of the Working Group Participants and nature of support and objections.  The Maintainer will document evidence of consensus in accordance with these requirements. 
+
+**2.2.	Appeal Process.**  Decisions may be appealed be via a pull request or an issue, and that appeal will be considered by the Maintainer in good faith, who will respond in writing within a reasonable time.
+
+## 3.	Ways of Working.
+
+Inspired by [ANSI’s Essential Requirements for Due Process](https://share.ansi.org/Shared%20Documents/Standards%20Activities/American%20National%20Standards/Procedures,%20Guides,%20and%20Forms/2020_ANSI_Essential_Requirements.pdf), Community Specification Working Groups must adhere to consensus-based due process requirements.  These requirements apply to activities related to the development of consensus for approval, revision, reaffirmation, and withdrawal of Community Specifications.  Due process means that any person (organization, company, government agency, individual, etc.) with a direct and material interest has a right to participate by: a) expressing a position and its basis, b) having that position considered, and c) having the right to appeal. Due process allows for equity and fair play. The following constitute the minimum acceptable due process requirements for the development of consensus.
+
+**3.1.	Openness.**  Participation shall be open to all persons who are directly and materially affected by the activity in question. There shall be no undue financial barriers to participation. Voting membership on the consensus body shall not be conditional upon membership in any organization, nor unreasonably restricted on the basis of technical qualifications or other such requirements.  Membership in a Working Group’s parent organization, if any, may be required.
+
+**3.2.	Lack of Dominance.**  The development process shall not be dominated by any single interest category, individual or organization. Dominance means a position or exercise of dominant authority, leadership, or influence by reason of superior leverage, strength, or representation to the exclusion of fair and equitable consideration of other viewpoints.
+
+**3.3.	Balance.**  The development process should have a balance of interests. Participants from diverse interest categories shall be sought with the objective of achieving balance.
+
+**3.4.	Coordination and Harmonization.**  Good faith efforts shall be made to resolve potential conflicts between and among deliverables developed under this Working Group and existing industry standards.
+
+**3.5.	Consideration of Views and Objections.**  Prompt consideration shall be given to the written views and objections of all Participants.
+
+**3.6.	Written procedures.**  This governance document and other materials documenting the Community Specification development process shall be available to any interested person.
+
+## 4.	Specification Development Process.  
+
+**4.1.	Pre-Draft.**  Any Participant may submit a proposed initial draft document as a candidate Draft Specification of that Working Group.  The Maintainer will designate each submission as a “Pre-Draft” document.
+
+**4.2.	Draft.**  Each Pre-Draft document of a Working Group must first be Approved to become a” Draft Specification”.  Once the Working Group approves a document as a Draft Specification, the Draft Specification becomes the basis for all going forward work on that specification.
+
+**4.3.	Working Group Approval.**  Once a Working Group believes it has achieved the objectives for its specification as described in the Scope, it will Approve that Draft Specification and progress it to “Approved Specification” status. 
+
+**4.4.	Publication and Submission.**  Upon the designation of a Draft Specification as an Approved Specification, the Maintainer will publish the Approved Specification in a manner agreed upon by the Working Group Participants (i.e., Working Group Participant only location, publicly available location, Working Group maintained website, Working Group member website, etc.).  The publication of an Approved Specification in a publicly accessible manner must include the terms under which the Approved Specification is being made available under.
+
+**4.5.	Submissions to Standards Bodies.**  No Draft Specification or Approved Specification may be submitted to another standards development organization without Working group Approval. Upon reaching Approval, the Maintainer will coordinate the submission of the applicable Draft Specification or Approved Specification to another standards development organization. Working Group Participants that developed that Draft Specification or Approved Specification agree to grant the copyright rights necessary to make those submissions.
+
+## 5. Non-Confidential, Restricted Disclosure.
+
+Information disclosed in connection with any Working Group activity, including but not limited to meetings, Contributions, and submissions, is not confidential, regardless of any markings or statements to the contrary.  Notwithstanding the foregoing, if the Working Group is collaborating via a private repository, the Participants will not make any public disclosures of that information contained in that private repository without the Approval of the Working Group.  

--- a/governance/6._Contributing.md
+++ b/governance/6._Contributing.md
@@ -1,0 +1,85 @@
+# Community Specification Contribution Policy 1.0
+
+This document provides the contribution policy for specifications and other documents developed using the Community Specification process in a repository (each a “Working Group”).  Additional or alternate contribution policies may be adopted and documented by the Working Group.
+
+## 1.	Contribution Guidelines. 
+
+This Working Group accepts contributions via pull requests. The following section outlines the process for merging contributions to the specification
+
+**1.1.	Issues.**  Issues are used as the primary method for tracking anything to do with this specification Working Group.
+
+**1.1.1.	Issue Types.**  There are three types of issues (each with their own corresponding label):
+
+**1.1.1.1.	Discussion.** These are support or functionality inquiries that we want to have a record of for future reference. Depending on the discussion, these can turn into "Spec Change" issues.
+
+**1.1.1.2.	Proposal.** Used for items that propose a new ideas or functionality that require a larger discussion. This allows for feedback from others before a specification change is actually written. All issues that are proposals should both have a label and an issue title of "Proposal: [the rest of the title]." A proposal can become a "Spec Change" and does not require a milestone.
+
+**1.1.1.3.	Spec Change:** These track specific spec changes and ideas until they are complete. They can evolve from "Proposal" and "Discussion" items, or can be submitted individually depending on the size. Each spec change should be placed into a milestone.
+
+## 2.	Issue Lifecycle.
+
+The issue lifecycle is mainly driven by the Maintainer. All issue types follow the same general lifecycle. Differences are noted below.
+
+**2.1.	Issue Creation.**
+
+**2.2.	Triage.**
+
+o	The Editor in charge of triaging will apply the proper labels for the issue. This includes labels for priority, type, and metadata.
+
+o	(If needed) Clean up the title to succinctly and clearly state the issue. Also ensure that proposals are prefaced with "Proposal".
+
+**2.3.	Discussion.**
+
+o	"Spec Change" issues should be connected to the pull request that resolves it.
+
+o	Whoever is working on a "Spec Change" issue should either assign the issue to themselves or make a comment in the issue saying that they are taking it.
+
+o	"Proposal" and "Discussion" issues should stay open until resolved.
+
+**2.4.	Issue Closure.**
+
+## 3.	How to Contribute a Patch.
+
+The Working Group uses pull requests to track changes. To submit a change to the specification:
+
+**3.1	Fork the Repo, modify the Specification to Address the Issue.**
+
+**3.2.	Submit a Pull Request.**
+
+## 4.	Pull Request Workflow.
+
+The next section contains more information on the workflow followed for Pull Requests.
+
+**4.1.	Pull Request Creation.**
+
+o	We welcome pull requests that are currently in progress. They are a great way to keep track of important work that is in-flight, but useful for others to see. If a pull request is a work in progress, it should be prefaced with "WIP: [title]". You should also add the wip label Once the pull request is ready for review, remove "WIP" from the title and label.
+
+o	It is preferred, but not required, to have a pull request tied to a specific issue. There can be circumstances where if it is a quick fix then an issue might be overkill. The details provided in the pull request description would suffice in this case.
+
+**4.2.	Triage**
+
+o	The Editor in charge of triaging will apply the proper labels for the issue. This should include at least a size label, a milestone, and awaiting review once all labels are applied. 
+
+**4.3.	Reviewing/Discussion.**
+
+o	All reviews will be completed using the review tool.
+
+o	A "Comment" review should be used when there are questions about the spec that should be answered, but that don't involve spec changes. This type of review does not count as approval.
+
+o	A "Changes Requested" review indicates that changes to the spec need to be made before they will be merged.
+
+o	Reviewers should update labels as needed (such as needs rebase).
+
+o	When a review is approved, the reviewer should add LGTM as a comment.
+
+o	Final approval is required by a designated Editor. Merging is blocked without this final approval. Editors will factor reviews from all other reviewers into their approval process.
+
+**4.4.	Responsive.** Pull request owner should try to be responsive to comments by answering questions or changing text. Once all comments have been addressed, the pull request is ready to be merged.
+
+**4.5.	Merge or Close.**
+
+o	A pull request should stay open until a Maintainer has marked the pull request as approved.
+
+o	Pull requests can be closed by the author without merging.
+
+o	Pull requests may be closed by a Maintainer if the decision is made that it is not going to be merged.

--- a/governance/7._CS_Template.md
+++ b/governance/7._CS_Template.md
@@ -1,0 +1,176 @@
+# Community Specification Template 1.0
+
+Community Specifications are recommended to be drafted in accordance with international best practices.  Doing so provides clarity, helps adoption, and also eases the transition of this specification to other standards body if so desired.  Accordingly, the recommended template below is based on ISO standard drafting conventions.
+
+To help you, this guide on writing standards was produced by the ISO/TMB and is available at https://www.iso.org/iso/how-to-write-standards.pdf.
+
+A model manuscript of a draft International Standard (known as “The Rice Model”) is available at https://www.iso.org/iso/model_document-rice_model.pdf.
+
+In addition, we recommend using the key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" as described in RFC 2119 -  https://tools.ietf.org/html/rfc2119
+
+ 
+## Title
+### Version _______
+### Status (Pre-draft, Draft, Approved)
+
+ 
+© _________________
+
+This specification is subject to the Community Specification License 1.0, available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
+
+ 
+
+## Contents
+Foreword	i
+
+Introduction	i
+
+1	Scope (mandatory)	1
+
+2	Normative references (mandatory)	1
+
+3	Terms and definitions (mandatory)	1
+
+4	Clause title autonumber	1
+
+5	Clause title	1
+
+5.1	Subclause autonumber	1
+
+5.1.1	Subclause autonumber	1
+
+6	Clause title	1
+
+Annex A (informative)  
+
+Bibliography	1
+
+
+## Foreword
+
+Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. No party shall not be held responsible for identifying any or all such patent rights.
+
+Any trade name used in this document is information given for the convenience of users and does not constitute an endorsement.
+
+This document was prepared by [Insert name of group].
+
+This second/third/… edition cancels and replaces the first/second/… edition (#####:####), which has been technically revised.
+The main changes compared to the previous edition are as follows:
+—	xxx xxxxxxx xxx xxxx
+
+Known patent licensing exclusions are available in the specification’s repository’s Notices.md file.
+
+Any feedback or questions on this document should be directed to specifications repository, located at _________________.
+
+THESE MATERIALS ARE PROVIDED “AS IS.” The Contributors and Licensees expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to the materials.  The entire risk as to implementing or otherwise using the materials is assumed by the implementer and user. IN NO EVENT WILL THE CONTRIBUTORS OR LICENSEES BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Introduction
+Type text.
+
+ 
+## Title (Introductory element — Main element — Part : Part title)
+1	Scope (mandatory)
+
+Type text.
+
+2	Normative references (mandatory)
+
+Two options of text (remove the inappropriate option).
+
+1)	The normative references shall be introduced by the following wording.
+
+The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.
+
+ISO ##### #, General title — Part #: Title of part
+
+ISO ##### ##:20##, General title — Part ##: Title of part
+
+2)	If no references exist, include the following phrase below the clause title:
+There are no normative references in this document.
+
+3	Terms and definitions (mandatory)
+
+Four options of text (remove the inappropriate options).
+
+1)	If all the specific terms and definitions are provided in Clause 3, use the following introductory text:
+
+For the purposes of this document, the following terms and definitions apply.
+
+2)	If reference is given to an external document, use the following introductory text:
+
+For the purposes of this document, the terms and definitions given in [external document reference xxx] apply.
+
+3)	If terms and definitions are provided in Clause 3, in addition to a reference to an external document, use the following introductory text:
+
+For the purposes of this document, the terms and definitions given in [external document reference xxx] and the following apply.
+
+4)	If there are no terms and definitions provided, use the following introductory text:
+
+No terms and definitions are listed in this document.
+
+The list below is always included after each option:
+
+ISO and IEC maintain terminological databases for use in standardization at the following addresses:
+
+—	ISO Online browsing platform: available at https://www.iso.org/obp
+
+—	IEC Electropedia: available at http://www.electropedia.org/
+
+
+3.1
+
+term
+
+text of the definition
+
+Note 1 to entry: Text of the note.
+
+[SOURCE: …]
+
+3.2
+
+term
+
+text of the definition
+
+4	Clause title 
+
+Type text.
+
+5	Clause title
+
+Type text.
+
+Use subclauses if required e.g. 5.1 or 5.1.1. For example:
+
+5.1	Subclause 
+
+5.1.1	Subclause 
+
+6	Clause title
+
+Example of codes:
+
+## Annex A
+
+(informative)
+
+Annex title e.g. Example of a figure and a table
+
+A.1	Clause title autonumber
+
+Use subclauses if required e.g. A.1.1 or A.1.1.1. For example:
+
+A.1.1	Subclause autonumber
+
+A.1.1.1	Subclause autonumber
+
+Type text.
+
+Dimensions in millimetres
+
+## Bibliography
+
+[1]	ISO ##### #, General title — Part #: Title of part
+
+[2]	ISO ##### ##:20##, General title — Part ##: Title of part

--- a/governance/8._Code_of_Conduct.md
+++ b/governance/8._Code_of_Conduct.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement as set forth in the repository's Notice.md file. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the project community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/governance/Readme.md
+++ b/governance/Readme.md
@@ -1,0 +1,25 @@
+# Community Specification
+
+This project utilizes the [Community Specification License and Framework](https://communityspec.dev) for contributions to the specification deliverable. 
+
+## What is the Community Specification For?
+
+The Community Specification process is a repository-based approach for creating standards and specifications in version control systems, such as Git. 
+
+## What is the benefit?
+
+The Community Specification allows you to start a specification development effort as easily as an open source project.  The Community Specification incorporates the terms and processes required for standards and specification development, including legal terms, intellectual property issues, due process, and governance.  It also provides the mechanisms to allow your project to grow and scale.  For example, the Community Specification provides the basis to take your specification to other standards bodies, including international standards bodies, for formal standardization if your community desires to pursue those options.
+
+## How to get started?
+
+Instructions for using the Community Specification are included in the ..Getting Started.md file.
+
+## Could I just use an open source license for my specifications? Why should I use a specification license?
+
+Open source is collaboration around a specific codebase, while specifications provide a blueprint developers implement in different ways in many different codebases. Accordingly, open source licenses provide terms to use and modify a particular codebase and specification licenses are designed to provide terms for separate independent implementations of the specification. Because of this, if you use an open source license for specifications, people implementing those specifications may be doing so without the meaningful copyright or patent grants that you expect.
+
+A second difference is that common open source software and specification licenses tend to have different coverage scopes for intellectual property terms. Open source licenses generally grant terms scoped only to a contributor's contributions. Specification licenses, however, generally cover implementations of the entire specification, regardless of who made the actual contribution. Because the specification will often be developed with contributions from multiple organizations, the various contributing organizations will often want to review and approve the full specification before extending patent commitments to the final, combined result. 
+
+## Who developed the Community Specification
+
+The Community Specification has been developed via the [Joint Development Foundation](http://www.jointdevelopment.org), with inspiration from the [Open Web Foundation agreements](http://openwebfoundation.org) and the [Alliance for Open Media Patent License 1.0](http://aomedia.org/license/patent-license/).


### PR DESCRIPTION
adding patent licensing materials to cover spec development for openvex as discussed with Dan, Tracy & Adolfo. Information about community spec can be found at communityspec.dev. Once merged, will need to update governance/2._Scope.md. 