### PR TITLE
fix: Add statements field to document in spec

### DIFF
--- a/OPENVEX-SPEC.md
+++ b/OPENVEX-SPEC.md
@@ -161,6 +161,7 @@ The following table lists the fields in the document struct
 | last_updated | ✕ | Date of last modification to the document. |
 | version | ✓ | Version is the document version. It must be incremented when any content within the VEX document changes, including any VEX statements included within the VEX document. |
 | tooling | ✕ | Tooling expresses how the VEX document and contained VEX statements were generated. It may specify tools or automated processes used in the document or statement generation. |
+| statements | ✓ | The list of statements to contain within the document. |
 
 ### Statement
 


### PR DESCRIPTION
Statements is missing in the Document Struct Fields table within the spec document. The missing row has been added and marked as required to conform with the JSON schema.

Fixes #52 