### PR TITLE
schema: Add missing "type" for statement items

### DIFF
--- a/openvex_json_schema.json
+++ b/openvex_json_schema.json
@@ -199,6 +199,7 @@
             "minItems": 1,
             "description": "A statement is an assertion made by the document's author about the impact a vulnerability has on one or more software 'products'.",
             "items": {
+                "type": "object",
                 "properties": {
                     "@id": {
                         "type": "string",


### PR DESCRIPTION
The JSON schema currently allows the statements list to contain a null value (i.e., `"statements": [null]`). This is because no type is specified for items. Setting type to object should only allow statement objects to be added to the list.

Fixes #55