### PR TITLE
README: Fix incorrect data type in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ and one or more
   "author": "Wolfi J Inkinson",
   "role": "Document Creator",
   "timestamp": "2023-01-08T18:02:03.647787998-06:00",
-  "version": "1",
+  "version": 1,
   "statements": [
     {
       "vulnerability": {


### PR DESCRIPTION
Example shows version as a string and not an integer. The spec requires version to be an integer. The example has been updated to an integer for clarity.

Fixes #56