### PR TITLE
fix(schema): remove redundant 'type' alongside 'enum' in JSON schema

### DIFF
--- a/openvex_json_schema.json
+++ b/openvex_json_schema.json
@@ -1,317 +1,336 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/openvex/spec/openvex_json_schema_0.2.0.json",
-    "title": "OpenVEX",
-    "description": "OpenVEX is an implementation of the Vulnerability Exploitability Exchange (VEX for short) that is designed to be minimal, compliant, interoperable, and embeddable.",
-    "type": "object",
-    "$defs": {
-        "vulnerability": {
-            "type": "object",
-            "properties": {
-                "@id": {
-                    "type": "string",
-                    "format": "iri",
-                    "description": "An Internationalized Resource Identifier (IRI) identifying the struct."
-                },
-                "name": {
-                    "type": "string",
-                    "description": "A string with the main identifier used to name the vulnerability."
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Optional free form text describing the vulnerability."
-                },
-                "aliases": {
-                    "type": "array",
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "A list of strings enumerating other names under which the vulnerability may be known."
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "additionalProperties": false
-        },
-        "identifiers": {
-            "type": "object",
-            "properties": {
-                "purl": {
-                    "type": "string",
-                    "description": "Package URL"
-                },
-                "cpe22": {
-                    "type": "string",
-                    "description": "Common Platform Enumeration v2.2"
-                },
-                "cpe23": {
-                    "type": "string",
-                    "description": "Common Platform Enumeration v2.3"
-                }
-            },
-            "additionalProperties": false,
-            "anyOf": [
-                { "required": ["purl"] },
-                { "required": ["cpe22"] },
-                { "required": ["cpe23"] }
-              ]
-        },
-        "hashes": {
-            "type": "object",
-            "properties": {
-                "md5": {
-                    "type": "string"
-                },
-                "sha1": {
-                    "type": "string"
-                },
-                "sha-256": {
-                    "type": "string"
-                },
-                "sha-384": {
-                    "type": "string"
-                },
-                "sha-512": {
-                    "type": "string"
-                },
-                "sha3-224": {
-                    "type": "string"
-                },
-                "sha3-256": {
-                    "type": "string"
-                },
-                "sha3-384": {
-                    "type": "string"
-                },
-                "sha3-512": {
-                    "type": "string"
-                },
-                "blake2s-256": {
-                    "type": "string"
-                },
-                "blake2b-256": {
-                    "type": "string"
-                },
-                "blake2b-512": {
-                    "type": "string"
-                }
-            },
-            "additionalProperties": false
-        },
-        "subcomponent": {
-            "type": "object",
-            "properties": {
-                "@id": {
-                    "type": "string",
-                    "format": "iri",
-                    "description": "Optional IRI identifying the component to make it externally referenceable."
-                },
-                "identifiers": {
-                    "$ref": "#/$defs/identifiers",
-                    "description": "Optional IRI identifying the component to make it externally referenceable."
-                },
-                "hashes": {
-                    "$ref": "#/$defs/hashes",
-                    "description": "Map of cryptographic hashes of the component."
-                }
-            },
-            "additionalProperties": false,
-            "anyOf": [
-                { "required": ["@id"] },
-                { "required": ["identifiers"] }
-              ]
-        },
-        "component": {
-            "type": "object",
-            "properties": {
-                "@id": {
-                    "type": "string",
-                    "format": "iri",
-                    "description": "Optional IRI identifying the component to make it externally referenceable."
-                },
-                "identifiers": {
-                    "$ref": "#/$defs/identifiers",
-                    "description": "A map of software identifiers where the key is the type and the value the identifier."
-                },
-                "hashes": {
-                    "$ref": "#/$defs/hashes",
-                    "description": "Map of cryptographic hashes of the component."
-                },
-                "subcomponents": {
-                    "type": "array",
-                    "uniqueItems": true,
-                    "description": "List of subcomponent structs describing the subcomponents subject of the VEX statement.",
-                    "items": {
-                        "$ref": "#/$defs/subcomponent"
-                    }
-                }
-            },
-            "additionalProperties": false,
-            "anyOf": [
-                { "required": ["@id"] },
-                { "required": ["identifiers"] }
-              ]
-        }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/openvex/spec/openvex_json_schema_0.2.0.json",
+  "title": "OpenVEX",
+  "description": "OpenVEX is an implementation of the Vulnerability Exploitability Exchange (VEX for short) that is designed to be minimal, compliant, interoperable, and embeddable.",
+  "type": "object",
+  "required": [
+    "@context",
+    "@id",
+    "author",
+    "timestamp",
+    "version",
+    "statements"
+  ],
+  "properties": {
+    "@context": {
+      "description": "The URL linking to the OpenVEX context definition.",
+      "type": "string",
+      "format": "uri"
     },
-    "properties": {
-        "@context": {
+    "@id": {
+      "description": "The IRI identifying the VEX document.",
+      "type": "string",
+      "format": "iri"
+    },
+    "author": {
+      "description": "Author is the identifier for the author of the VEX statement.",
+      "type": "string"
+    },
+    "last_updated": {
+      "description": "Date of last modification to the document.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "role": {
+      "description": "Role describes the role of the document author.",
+      "type": "string"
+    },
+    "statements": {
+      "description": "A statement is an assertion made by the document's author about the impact a vulnerability has on one or more software 'products'.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "status": {
+                  "const": "not_affected"
+                }
+              }
+            },
+            "then": {
+              "anyOf": [
+                {
+                  "required": [ "justification" ]
+                },
+                {
+                  "required": [ "impact_statement" ]
+                }
+              ]
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "status": {
+                  "const": "affected"
+                }
+              }
+            },
+            "then": {
+              "required": [ "action_statement" ]
+            }
+          }
+        ],
+        "required": [ "vulnerability", "status" ],
+        "properties": {
+          "@id": {
+            "description": "Optional IRI identifying the statement to make it externally referenceable.",
             "type": "string",
-            "format": "uri",
-            "description": "The URL linking to the OpenVEX context definition."
-        },
-        "@id": {
+            "format": "iri"
+          },
+          "action_statement": {
+            "description": "For a statement with affected status, a VEX statement MUST include a statement that SHOULD describe actions to remediate or mitigate the vulnerability.",
+            "type": "string"
+          },
+          "action_statement_timestamp": {
+            "description": "The timestamp when the action statement was issued.",
             "type": "string",
-            "format": "iri",
-            "description": "The IRI identifying the VEX document."
-        },
-        "author": {
+            "format": "date-time"
+          },
+          "impact_statement": {
+            "description": "For statements conveying a not_affected status, a VEX statement MUST include either a status justification or an impact_statement informing why the product is not affected by the vulnerability.",
+            "type": "string"
+          },
+          "justification": {
+            "description": "For statements conveying a not_affected status, a VEX statement MUST include either a status justification or an impact_statement informing why the product is not affected by the vulnerability.",
+            "enum": [
+              "component_not_present",
+              "vulnerable_code_not_present",
+              "vulnerable_code_not_in_execute_path",
+              "vulnerable_code_cannot_be_controlled_by_adversary",
+              "inline_mitigations_already_exist"
+            ]
+          },
+          "last_updated": {
+            "description": "Timestamp when the statement was last updated.",
             "type": "string",
-            "description": "Author is the identifier for the author of the VEX statement."
-        },
-        "role": {
-            "type": "string",
-            "description": "Role describes the role of the document author."
-        },
-        "timestamp": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Timestamp defines the time at which the document was issued."
-        },
-        "last_updated": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Date of last modification to the document."
-        },
-        "version": {
-            "type": "integer",
-            "minimum": 1,
-            "description": "Version is the document version."
-        },
-        "tooling": {
-            "type": "string",
-            "description": "Tooling expresses how the VEX document and contained VEX statements were generated."
-        },
-        "statements": {
+            "format": "date-time"
+          },
+          "products": {
+            "description": "List of product structs that the statement applies to.",
             "type": "array",
             "uniqueItems": true,
-            "minItems": 1,
-            "description": "A statement is an assertion made by the document's author about the impact a vulnerability has on one or more software 'products'.",
             "items": {
-                "type": "object",
-                "properties": {
-                    "@id": {
-                        "type": "string",
-                        "format": "iri",
-                        "description": "Optional IRI identifying the statement to make it externally referenceable."
-                    },
-                    "version": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "description": "Optional integer representing the statement's version number."
-                    },
-                    "vulnerability": {
-                        "$ref": "#/$defs/vulnerability",
-                        "description": "A struct identifying the vulnerability."
-                    },
-                    "timestamp": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Timestamp is the time at which the information expressed in the statement was known to be true."
-                    },
-                    "last_updated": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Timestamp when the statement was last updated."
-                    },
-                    "products": {
-                        "type": "array",
-                        "uniqueItems": true,
-                        "description": "List of product structs that the statement applies to.",
-                        "items": {
-                            "$ref": "#/$defs/component"
-                        }
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "not_affected",
-                            "affected",
-                            "fixed",
-                            "under_investigation"
-                        ],
-                        "description": "A VEX statement MUST provide the status of the vulnerabilities with respect to the products and components listed in the statement."
-                    },
-                    "supplier": {
-                        "type": "string",
-                        "description": "Supplier of the product or subcomponent."
-                    },
-                    "status_notes": {
-                        "type": "string",
-                        "description": "A statement MAY convey information about how status was determined and MAY reference other VEX information."
-                    },
-                    "justification": {
-                        "type": "string",
-                        "enum": [
-                            "component_not_present",
-                            "vulnerable_code_not_present",
-                            "vulnerable_code_not_in_execute_path",
-                            "vulnerable_code_cannot_be_controlled_by_adversary",
-                            "inline_mitigations_already_exist"
-                        ],
-                        "description": "For statements conveying a not_affected status, a VEX statement MUST include either a status justification or an impact_statement informing why the product is not affected by the vulnerability."
-                    },
-                    "impact_statement": {
-                        "type": "string",
-                        "description": "For statements conveying a not_affected status, a VEX statement MUST include either a status justification or an impact_statement informing why the product is not affected by the vulnerability."
-                    },
-                    "action_statement": {
-                        "type": "string",
-                        "description": "For a statement with affected status, a VEX statement MUST include a statement that SHOULD describe actions to remediate or mitigate the vulnerability."
-                    },
-                    "action_statement_timestamp": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "The timestamp when the action statement was issued."
-                    }
-                },
-                "required": [
-                    "vulnerability",
-                    "status"
-                ],
-                "additionalProperties": false,
-                "allOf": [
-                    {
-                        "if": {
-                            "properties": { "status": { "const": "not_affected" }}
-                        },
-                        "then": {
-                            "anyOf": [
-                                { "required": ["justification"]},
-                                { "required": ["impact_statement"]}
-                            ]
-                        }
-                    },
-                    {
-                        "if": {
-                            "properties": { "status": { "const": "affected" }}
-                        },
-                        "then": {
-                            "required": ["action_statement"]
-                        }
-                    }
-                ]
+              "$ref": "#/$defs/component"
             }
-        }
+          },
+          "status": {
+            "description": "A VEX statement MUST provide the status of the vulnerabilities with respect to the products and components listed in the statement.",
+            "enum": [
+              "not_affected",
+              "affected",
+              "fixed",
+              "under_investigation"
+            ]
+          },
+          "status_notes": {
+            "description": "A statement MAY convey information about how status was determined and MAY reference other VEX information.",
+            "type": "string"
+          },
+          "supplier": {
+            "description": "Supplier of the product or subcomponent.",
+            "type": "string"
+          },
+          "timestamp": {
+            "description": "Timestamp is the time at which the information expressed in the statement was known to be true.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "version": {
+            "description": "Optional integer representing the statement's version number.",
+            "type": "integer",
+            "minimum": 1
+          },
+          "vulnerability": {
+            "description": "A struct identifying the vulnerability.",
+            "$ref": "#/$defs/vulnerability"
+          }
+        },
+        "additionalProperties": false
+      }
     },
-    "required": [
-        "@context",
-        "@id",
-        "author",
-        "timestamp",
-        "version",
-        "statements"
-    ],
-    "additionalProperties": false
+    "timestamp": {
+      "description": "Timestamp defines the time at which the document was issued.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "tooling": {
+      "description": "Tooling expresses how the VEX document and contained VEX statements were generated.",
+      "type": "string"
+    },
+    "version": {
+      "description": "Version is the document version.",
+      "type": "integer",
+      "minimum": 1
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "component": {
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [ "@id" ]
+        },
+        {
+          "required": [ "identifiers" ]
+        }
+      ],
+      "properties": {
+        "@id": {
+          "description": "Optional IRI identifying the component to make it externally referenceable.",
+          "type": "string",
+          "format": "iri"
+        },
+        "hashes": {
+          "description": "Map of cryptographic hashes of the component.",
+          "$ref": "#/$defs/hashes"
+        },
+        "identifiers": {
+          "description": "A map of software identifiers where the key is the type and the value the identifier.",
+          "$ref": "#/$defs/identifiers"
+        },
+        "subcomponents": {
+          "description": "List of subcomponent structs describing the subcomponents subject of the VEX statement.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/subcomponent"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "hashes": {
+      "type": "object",
+      "properties": {
+        "blake2b-256": {
+          "type": "string"
+        },
+        "blake2b-512": {
+          "type": "string"
+        },
+        "blake2s-256": {
+          "type": "string"
+        },
+        "md5": {
+          "type": "string"
+        },
+        "sha-256": {
+          "type": "string"
+        },
+        "sha-384": {
+          "type": "string"
+        },
+        "sha-512": {
+          "type": "string"
+        },
+        "sha1": {
+          "type": "string"
+        },
+        "sha3-224": {
+          "type": "string"
+        },
+        "sha3-256": {
+          "type": "string"
+        },
+        "sha3-384": {
+          "type": "string"
+        },
+        "sha3-512": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "identifiers": {
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [ "purl" ]
+        },
+        {
+          "required": [ "cpe22" ]
+        },
+        {
+          "required": [ "cpe23" ]
+        }
+      ],
+      "properties": {
+        "cpe22": {
+          "description": "Common Platform Enumeration v2.2",
+          "type": "string"
+        },
+        "cpe23": {
+          "description": "Common Platform Enumeration v2.3",
+          "type": "string"
+        },
+        "purl": {
+          "description": "Package URL",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "subcomponent": {
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [ "@id" ]
+        },
+        {
+          "required": [ "identifiers" ]
+        }
+      ],
+      "properties": {
+        "@id": {
+          "description": "Optional IRI identifying the component to make it externally referenceable.",
+          "type": "string",
+          "format": "iri"
+        },
+        "hashes": {
+          "description": "Map of cryptographic hashes of the component.",
+          "$ref": "#/$defs/hashes"
+        },
+        "identifiers": {
+          "description": "Optional IRI identifying the component to make it externally referenceable.",
+          "$ref": "#/$defs/identifiers"
+        }
+      },
+      "additionalProperties": false
+    },
+    "vulnerability": {
+      "type": "object",
+      "required": [ "name" ],
+      "properties": {
+        "description": {
+          "description": "Optional free form text describing the vulnerability.",
+          "type": "string"
+        },
+        "@id": {
+          "description": "An Internationalized Resource Identifier (IRI) identifying the struct.",
+          "type": "string",
+          "format": "iri"
+        },
+        "aliases": {
+          "description": "A list of strings enumerating other names under which the vulnerability may be known.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "A string with the main identifier used to name the vulnerability.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
 }


### PR DESCRIPTION
### Description

This PR addresses warnings from the JSON schema linter regarding the use of type alongside enum in the openvex_json_schema.json file. According to best practices, specifying type with enum is redundant since the enumeration values already imply their types. The redundant type fields have been removed from the relevant properties (such as justification and status), ensuring cleaner and more standards-compliant schema definitions.

### Screenshots

Before and after:

![image](https://github.com/user-attachments/assets/4e0c1215-4a37-4f7c-a545-3de5a562c023)

### Note

I, along with [Juan](https://www.jviotti.com/)  (JSON Schema TSC member) are defining linting rules for JSON Schema as a Part of a [GSoC (Google Summer of code) project](https://github.com/json-schema-org/community/issues/856) here - https://github.com/Karan-Palan/JSON-Schema-Linting, and implementing their auto-fixes here - https://github.com/sourcemeta/jsonschema/blob/main/docs/lint.markdown. If beneficial to the project, I suggest integrating the linter with it to write the best schemas and catch any errors and follow best practices.
