### PR TITLE
Allow empty statements list in schema

### DIFF
--- a/OPENVEX-SPEC.md
+++ b/OPENVEX-SPEC.md
@@ -35,7 +35,7 @@ structures (see [Inheritance Flow](#inheritance-flow)).
 
 ## VEX Documents
 
-A VEX document is a data structure grouping one or more VEX statements.
+A VEX document is a data structure grouping zero or more VEX statements.
 Documents also have timestamps, which may cascade down to statements (see
 [Inheritance Flow](#inheritance-flow)). Documents can also be versioned.
 
@@ -74,7 +74,7 @@ described in [RFC2119].
 
 #### Document
 
-A data structure that groups together one or more VEX statements. A document
+A data structure that groups together zero or more VEX statements. A document
 MUST define a timestamp to express when it was issued.
 
 #### Encapsulating Document
@@ -119,6 +119,11 @@ product's dependencies.
 A VEX document consists of two parts: The document metadata and a collection
 of statements. Some fields in the document metadata are required.
 
+__Note:__ A document with an empty `statements` array is valid when all required
+metadata fields (`@context`, `@id`, `author`, `timestamp`, `version`) are present.
+An empty `statements` list indicates that the author is not asserting any
+vulnerability impact at the time the document was issued.
+
 OpenVEX documents are serialized in json-ld structs. File encoding MUST be UTF8.
 
 Here is a sample of a minimal OpenVEX document:
@@ -161,7 +166,7 @@ The following table lists the fields in the document struct
 | last_updated | ✕ | Date of last modification to the document. |
 | version | ✓ | Version is the document version. It must be incremented when any content within the VEX document changes, including any VEX statements included within the VEX document. |
 | tooling | ✕ | Tooling expresses how the VEX document and contained VEX statements were generated. It may specify tools or automated processes used in the document or statement generation. |
-| statements | ✓ | The list of statements to contain within the document. |
+| statements | ✓ | The list of statements contained in the document. May be empty. |
 
 ### Statement
 

--- a/openvex_json_schema.json
+++ b/openvex_json_schema.json
@@ -196,7 +196,7 @@
         "statements": {
             "type": "array",
             "uniqueItems": true,
-            "minItems": 1,
+            "minItems": 0,
             "description": "A statement is an assertion made by the document's author about the impact a vulnerability has on one or more software 'products'.",
             "items": {
                 "type": "object",


### PR DESCRIPTION
Hi,

just a quick PR.

Based on the contributing guidelines (namely [Section 4.1](https://github.com/openvex/spec/blob/main/governance/6._Contributing.md#4pull-request-workflow)) I did not create an issue as this PR is a one liner.

I was recently playing around with the OpenVEX format, and implemented it into my public python development [template](https://github.com/TimCares/snake-shed) (commit [here](https://github.com/TimCares/snake-shed/commit/54ea130571ad262f74a78b81fb8cf7315c150053)).

However, I found that when there are no existing CVEs to triage, and the `statements` field of the [spec](https://github.com/openvex/spec/blob/main/openvex_json_schema.json) is empty, it leads to a json validation error because the [spec](https://github.com/openvex/spec/blob/main/openvex_json_schema.json) requires at least one `statement` being present.

Users of this format therefore either have to delete the file, or find some other workaround, as I currently have in my template.

I thought that this was a little cumbersome, as an empty `statements` fields is also quite expressive: “There are (currently) no CVEs to triage in this project.”

Therefore, I propose a one line fix:

```diff
- “minItems": 1,
+ “minItems": 0,
```

---

I am aware of the fact that this might break code of other software/libraries consuming the OpenVex format.
However, from what I saw [`trivy`](https://github.com/aquasecurity/trivy) seems to be a main consumer of this format, which is why I checked the source code consuming OpenVex:

Trivy uses the [vex go client](https://github.com/openvex/go-vex), which can be seen in the file [`pkg/vex/openvex.go`](https://github.com/aquasecurity/trivy/blob/7a69b8fb4060def50592a5b1c34b8455210d63f3/pkg/vex/openvex.go).

The go client defines this structure for the OpenVex format:

```go
// The VEX type represents a VEX document and all of its contained information.
type VEX struct {
	Metadata
	Statements []Statement `json:"statements"`
}
```
Link [here](https://github.com/openvex/go-vex/blob/d62ff11fe8971a9e623677e843f4dba02e8ae7f1/pkg/vex/vex.go#L57-L61).

Since this allows an empty `statements` list, there is also a **drift** between the schema in the go client and the json schema.

Using a test run of trivy with OpenVex I verified that trivy can indeed handle an empty `statements` field:

```json
{
  "@context": "https://openvex.dev/ns/v0.2.0",
  "@id": "https://openvex.dev/docs/public/vex-project-template",
  "author": "Project Maintainers",
  "timestamp": "2026-06-15T14:13:08Z",
  "version": 1,
  "statements": []
}
```

```bash
docker run --rm \
  -v "path/to/empty/openvex.json:/vex/openvex.json:ro" \
  ghcr.io/aquasecurity/trivy:0.70.0 image \
  --severity HIGH,CRITICAL \
  --vex /vex/openvex.json \
  --exit-code 0 \
  alpine:3.20
```

The command runs through.

Therefore, I conclude that at least for Trivy, this change/fix can be deemed safe (however, it might not be safe for all consumers).